### PR TITLE
Fix logic for baits that increase rarity rates

### DIFF
--- a/scripts/scr_KSW_Game_SetPool/scr_KSW_Game_SetPool.gml
+++ b/scripts/scr_KSW_Game_SetPool/scr_KSW_Game_SetPool.gml
@@ -3,10 +3,10 @@
 function scr_KSW_Game_SetPool(playerNum)
 {
 	var rate = [];
-	rate[0] = 24 - ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "0rarity"]) * 5);
-	rate[1] = 15 - ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "1rarity"]) * 4);
-	rate[2] = 9 - ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "2rarity"]) * 3);
-	rate[3] = 3 - ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "3rarity"]) * 2);
+	rate[0] = 24 + ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "0rarity"]) * 5);
+	rate[1] = 15 + ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "1rarity"]) * 4);
+	rate[2] = 9 + ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "2rarity"]) * 3);
+	rate[3] = 3 + ((global.KSW_EquippedBaitID[playerNum] == global.KSW_BaitIDs[? "3rarity"]) * 2);
 	
 	var list = [];
 	var index = 0;


### PR DESCRIPTION
The logic to increase the weight of fish in a certain rarity if the right bait is equipped appears to be decreasing the odds when active rather than increase.